### PR TITLE
fixing internal links to use theme color in edit mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -143,6 +143,7 @@
 .cm-s-obsidian .cm-strong {
   color: var(--color-text-strong);
 }
+.cm-s-obsidian .cm-hmd-internal-link,
 .cm-s-obsidian .cm-formatting-link,
 .cm-s-obsidian .cm-link {
   color: var(--color-text-link) !important;


### PR DESCRIPTION
# I am submitting some updates to Firefly Theme

## I have changed
Making internal links use the `--color-text-link` color in edit mode (it already uses the theme color in preview mode)

### Added
commit is self explanatory

## Why should this have been updated
Internal links already use the theme color in preview mode, and since Obsidian added live preview to edit mode, it makes sense for the same color to be used in both modes.

Also internal links are barely legible in edit mode since they are dark purple on a dark background.
